### PR TITLE
fix: repair tests out of stock validation

### DIFF
--- a/src/__tests__/hooks/useCart.spec.tsx
+++ b/src/__tests__/hooks/useCart.spec.tsx
@@ -204,12 +204,12 @@ describe('useCart Hook', () => {
     );
   });
 
-  it('should not be able to increase a product amount when running out of stock', async () => {
+  it('should not be able to increase a product amount when product is out of stock', async () => {
     const productId = 2;
 
     apiMock.onGet(`stock/${productId}`).reply(200, {
       id: 1,
-      amount: 1,
+      amount: 0,
     });
 
     const { result, waitFor } = renderHook(useCart, {
@@ -354,12 +354,12 @@ describe('useCart Hook', () => {
     );
   });
 
-  it('should not be able to update a product amount when running out of stock', async () => {
+  it('should not be able to update a product amount when product is out of stock', async () => {
     const productId = 2;
 
     apiMock.onGet(`stock/${productId}`).reply(200, {
       id: 2,
-      amount: 1,
+      amount: 0,
     });
 
     const { result, waitFor } = renderHook(useCart, {


### PR DESCRIPTION
@josepholiveira @vinifraga The current logic validation in the tests for cases where product is running out of stock is misleading.
If there is still 1 product in stock, the user should be able to add it to the cart, the user shouldn't be able to add the product to the cart only if the product is *already* out of stock.