### PR TITLE
fix: Changed mock response

### DIFF
--- a/src/__tests__/hooks/useCart.spec.tsx
+++ b/src/__tests__/hooks/useCart.spec.tsx
@@ -208,7 +208,7 @@ describe('useCart Hook', () => {
     const productId = 2;
 
     apiMock.onGet(`stock/${productId}`).reply(200, {
-      id: 1,
+      id: 2,
       amount: 1,
     });
 


### PR DESCRIPTION
Changed id returned in "stock"
This is not a problem that directly affects the core of the application, it is just a "label" update.

```tsx
   const productId = 2;

   apiMock.onGet(`stock/${productId}`).reply(200, {
      id: 1,
      amount: 1,
   });
```
To  
```tsx
   const productId = 2;

   apiMock.onGet(`stock/${productId}`).reply(200, {
      id: 2,
      amount: 1,
   });
```
